### PR TITLE
241119 : 네트워크 / Lv.3

### DIFF
--- a/_eunjin/eunjin_네트워크.py
+++ b/_eunjin/eunjin_네트워크.py
@@ -1,0 +1,48 @@
+from collections import deque
+
+adj_list = []
+
+# 그래프 연결 요소의 개수 구하기
+
+
+def bfs(n, start_node, visited):
+    global adj_list
+
+    q = deque()
+    q.append(start_node)
+    visited[start_node] = True
+
+    while q:
+        curr_node = q.popleft()
+
+        for adj_node in adj_list[curr_node]:
+            if not visited[adj_node]:
+                q.append(adj_node)
+                visited[adj_node] = True
+
+    return 0
+
+
+def solution(n, computers):
+    global adj_list
+
+    # 인접리스트 초기화
+    adj_list = [[] for _ in range(n)]
+
+    for i in range(n):
+        for j in range(n):
+            if i == j:
+                continue
+            if computers[i][j] == 1:
+                adj_list[i].append(j)
+    print(adj_list)
+
+    visited = [False] * n
+    answer = 0
+
+    for i in range(n):
+        if not visited[i]:
+            bfs(n, i, visited)
+            answer += 1
+
+    return answer


### PR DESCRIPTION
### 🚀 문제 번호
Resolve: {#22}  
<br/>

### 🔍 구현 방법
<!-- 문제를 해결한 구체적인 방법을 설명해주세요. -->
그래프의 연결 요소의 개수를 구하는 문제로, 전체 n개의 노드를 돌면서 아직 방문하지 않은 노드라면 bfs 탐색을 실행하고 답 개수를 +1 해주었습니다.
```
from collections import deque

# 그래프 연결 요소의 개수 구하기

adj_list = []

def bfs(n, start_node, visited):
    global adj_list

    q = deque()
    q.append(start_node)
    visited[start_node] = True

    while q:
        curr_node = q.popleft()

        for adj_node in adj_list[curr_node]:
            if not visited[adj_node]:
                q.append(adj_node)
                visited[adj_node] = True

    return 0


def solution(n, computers):
    global adj_list

    # 인접리스트 초기화
    adj_list = [[] for _ in range(n)]

    for i in range(n):
        for j in range(n):
            if i == j:
                continue
            if computers[i][j] == 1:
                adj_list[i].append(j)
    print(adj_list)

    visited = [False] * n
    answer = 0

    for i in range(n):
        if not visited[i]:
            bfs(n, i, visited)
            answer += 1

    return answer
```
<br/>

### ⭐️ 리뷰 Point
<!-- 이 PR에 대한 논의하고 싶은 사항이나 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->


