### PR TITLE
241120 : 게임 맵 최단거리 / Lv.2

### DIFF
--- a/_eunjin/eunjin_게임_맵_최단거리.py
+++ b/_eunjin/eunjin_게임_맵_최단거리.py
@@ -1,0 +1,32 @@
+from collections import deque
+
+
+def solution(maps):
+    N = len(maps)
+    M = len(maps[0])
+
+    dy = [1, 0, -1, 0]
+    dx = [0, -1, 0, 1]
+
+    visited = [[False]*M for _ in range(N)]
+
+    q = deque()
+    q.append((0, 0, 1))  # y,x,dist
+    visited[0][0] = True
+
+    while q:
+        y, x, d = q.popleft()
+
+        if y == N - 1 and x == M-1:  # 상대 진영에 도착
+            return d
+
+        for i in range(4):
+            ny = y+dy[i]
+            nx = x+dx[i]
+
+            if 0 <= ny < N and 0 <= nx < M and not visited[ny][nx]:
+                if maps[ny][nx]:  # 다음 노드가 벽이 아닐 때에만
+                    q.append((ny, nx, d+1))
+                    visited[ny][nx] = True
+
+    return -1


### PR DESCRIPTION
### 🚀 문제 번호
Resolve: {#23}  
<br/>

### 🔍 구현 방법
<!-- 문제를 해결한 구체적인 방법을 설명해주세요. -->
간선 가중치가 없는 그래프의 n,m 노드에서 상대 진영 노드까지의 최단거리를 구해야하므로 bfs를 이용했습니다. 
```
from collections import deque


def solution(maps):
    N = len(maps)
    M = len(maps[0])

    dy = [1, 0, -1, 0]
    dx = [0, -1, 0, 1]

    visited = [[False]*M for _ in range(N)]

    q = deque()
    q.append((0, 0, 1))  # y,x,dist
    visited[0][0] = True

    while q:
        y, x, d = q.popleft()

        if y == N - 1 and x == M-1:  # 상대 진영에 도착
            return d

        for i in range(4):
            ny = y+dy[i]
            nx = x+dx[i]

            if 0 <= ny < N and 0 <= nx < M and not visited[ny][nx]:
                if maps[ny][nx]:  # 다음 노드가 벽이 아닐 때에만
                    q.append((ny, nx, d+1))
                    visited[ny][nx] = True

    return -1
```
<br/>

### ⭐️ 리뷰 Point
<!-- 이 PR에 대한 논의하고 싶은 사항이나 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->


